### PR TITLE
Allow the ./luarocks wrapper to access existing Lua environment

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -51,16 +51,14 @@ luarocks: config.unix $(builddir)/config-$(LUA_VERSION).lua
 	cp $(builddir)/config-$(LUA_VERSION).lua .luarocks/config-$(LUA_VERSION).lua
 	rm -f src/luarocks/core/hardcoded.lua
 	echo "#!/bin/sh" > luarocks
-	echo "unset LUA_PATH LUA_PATH_5_2 LUA_PATH_5_3 LUA_PATH_5_4 LUA_CPATH LUA_CPATH_5_2 LUA_CPATH_5_3 LUA_CPATH_5_4" >> luarocks
-	echo 'LUAROCKS_SYSCONFDIR="$(luarocksconfdir)" LUA_PATH="$(CURDIR)/src/?.lua;;" exec "$(LUA)" "$(CURDIR)/src/bin/luarocks" --project-tree="$(CURDIR)/lua_modules" "$$@"' >> luarocks
+	echo 'LUAROCKS_SYSCONFDIR="$(luarocksconfdir)" exec "$(LUA)" -e "package.path = \"$(CURDIR)/src/?.lua;\" .. package.path" "$(CURDIR)/src/bin/luarocks" --project-tree="$(CURDIR)/lua_modules" "$$@"' >> luarocks
 	chmod +rx ./luarocks
 	./luarocks init
 
 luarocks-admin: config.unix
 	rm -f src/luarocks/core/hardcoded.lua
 	echo "#!/bin/sh" > luarocks-admin
-	echo "unset LUA_PATH LUA_PATH_5_2 LUA_PATH_5_3 LUA_PATH_5_4 LUA_CPATH LUA_CPATH_5_2 LUA_CPATH_5_3 LUA_CPATH_5_4" >> luarocks-admin
-	echo 'LUAROCKS_SYSCONFDIR="$(luarocksconfdir)" LUA_PATH="$(CURDIR)/src/?.lua;;" exec "$(LUA)" "$(CURDIR)/src/bin/luarocks-admin" --project-tree="$(CURDIR)/lua_modules" "$$@"' >> luarocks-admin
+	echo 'LUAROCKS_SYSCONFDIR="$(luarocksconfdir)" exec "$(LUA)" -e "package.path = \"$(CURDIR)/src/?.lua;\" .. package.path" "$(CURDIR)/src/bin/luarocks-admin" --project-tree="$(CURDIR)/lua_modules" "$$@"' >> luarocks-admin
 	chmod +rx ./luarocks-admin
 
 $(builddir)/luarocks: src/bin/luarocks config.unix

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -145,13 +145,6 @@ install-binary: $(INSTALL_BINARY_FILES)
 	$(INSTALL) "$(buildbinarydir)/luarocks-admin.exe" "$(DESTDIR)$(bindir)/luarocks-admin"
 
 # ----------------------------------------
-# Bootstrap install
-# ----------------------------------------
-
-bootstrap: luarocks $(DESTDIR)$(luarocksconfdir)/config-$(LUA_VERSION).lua
-	./luarocks make --tree="$(DESTDIR)$(rocks_tree)"
-
-# ----------------------------------------
 # Windows binary build
 # ----------------------------------------
 
@@ -184,4 +177,4 @@ clean: windows-clean
 		./.luarocks \
 		./lua_modules
 
-.PHONY: all build install binary install-binary bootstrap clean windows-binary windows-clean
+.PHONY: all build install binary install-binary clean windows-binary windows-clean

--- a/configure
+++ b/configure
@@ -506,7 +506,5 @@ if [ "$LUA_INCDIR_SET" = "yes" ]; then echo "Lua include directory..............
 if [ "$LUA_LIBDIR_SET" = "yes" ]; then echo "Lua lib directory..................: $(GREEN "$LUA_LIBDIR")" ; fi
 echo
 echo "* Type $(BOLD make) and $(BOLD make install):"
-echo "  to install to $prefix as usual."
-echo "* Type $(BOLD make bootstrap):"
-echo "  to install LuaRocks into $rocks_tree as a rock."
+echo "  to install to $prefix."
 echo

--- a/smoke_test.sh
+++ b/smoke_test.sh
@@ -34,56 +34,6 @@ cd ..
 rm -rf foobar
 
 ################################################################################
-# test installation with make bootstrap
-################################################################################
-
-./configure --prefix=fooboot
-make bootstrap
-./luarocks --verbose
-./luarocks --verbose install inspect
-./luarocks --verbose show inspect
-./lua -e 'print(assert(require("inspect")(_G)))'
-./luarocks --verbose remove inspect
-cd fooboot
-bin/luarocks --verbose
-bin/luarocks --verbose install inspect
-bin/luarocks --verbose show inspect
-(
-   eval $(bin/luarocks path)
-   lua -e 'print(assert(require("inspect")(_G)))'
-)
-bin/luarocks --verbose remove inspect
-cd ..
-rm -rf fooboot
-
-################################################################################
-# test installation with luarocks install
-################################################################################
-
-./configure --prefix=foorock
-make bootstrap
-./luarocks make --pack-binary-rock
-cd foorock
-bin/luarocks install ../luarocks-*-1.all.rock
-bin/luarocks --verbose
-bin/luarocks --verbose install inspect
-bin/luarocks --verbose show inspect
-bin/luarocks install ../luarocks-*-1.all.rock --tree=../foorock2
-bin/luarocks --verbose remove inspect
-cd ../foorock2
-bin/luarocks --verbose
-bin/luarocks --verbose install inspect
-bin/luarocks --verbose show inspect
-(
-   eval $(bin/luarocks path)
-   lua -e 'print(assert(require("inspect")(_G)))'
-)
-bin/luarocks --verbose remove inspect
-cd ..
-rm -rf foorock
-rm -rf foorock2
-
-################################################################################
 
 if [ "$2" = "binary" ]
 then

--- a/spec/test_spec.lua
+++ b/spec/test_spec.lua
@@ -70,6 +70,32 @@ describe("luarocks test #integration", function()
          -- Assert that busted ran, whether successfully or not
          assert.match("%d+ success.* / %d+ failure.* / %d+ error.* / %d+ pending", output)
       end)
+
+      it("prepare", function()
+         finally(function()
+            -- delete downloaded and unpacked files
+            lfs.chdir(testing_paths.testrun_dir)
+            test_env.remove_dir("busted_project-0.1-1")
+            os.remove("busted_project-0.1-1.src.rock")
+         end)
+
+         -- make luassert
+         assert.is_true(run.luarocks_bool("download --server="..testing_paths.fixtures_repo_dir.." busted_project 0.1-1"))
+         assert.is_true(run.luarocks_bool("unpack busted_project-0.1-1.src.rock"))
+         lfs.chdir("busted_project-0.1-1/busted_project")
+         assert.is_true(run.luarocks_bool("make"))
+         
+         run.luarocks_bool("remove busted")
+         local prepareOutput = run.luarocks_bool("test --prepare")
+         assert.is_true(run.luarocks_bool("show busted"))
+          
+         -- Assert that "test --prepare" run successfully
+         assert.is_true(prepareOutput)
+
+         local output = run.luarocks("test")
+         assert.not_match(tostring(prepareOutput), output)
+         
+      end)
    end)
 end)
 

--- a/src/luarocks/argparse.lua
+++ b/src/luarocks/argparse.lua
@@ -2067,6 +2067,9 @@ function Parser:parse(args)
 end
 
 local function xpcall_error_handler(err)
+   if not debug then
+      return tostring(err)
+   end
    return tostring(err) .. "\noriginal " .. debug.traceback("", 2):sub(2)
 end
 

--- a/src/luarocks/cmd.lua
+++ b/src/luarocks/cmd.lua
@@ -146,6 +146,9 @@ local function process_server_args(args)
 end
 
 local function error_handler(err)
+   if not debug then
+      return err
+   end
    local mode = "Arch.: " .. (cfg and cfg.arch or "unknown")
    if package.config:sub(1, 1) == "\\" then
       if cfg and cfg.fs_use_modules then

--- a/src/luarocks/cmd/test.lua
+++ b/src/luarocks/cmd/test.lua
@@ -23,7 +23,8 @@ to separate LuaRocks arguments from test suite arguments.]],
       :args("?")
    cmd:argument("args", "Test suite arguments.")
       :args("*")
-
+   cmd:flag("--prepare", "Only install dependencies needed for testing only, but do not run the test")
+   
    cmd:option("--test-type", "Specify the test suite type manually if it was "..
       "not specified in the rockspec and it could not be auto-detected.")
       :argname("<type>")
@@ -31,7 +32,7 @@ end
 
 function cmd_test.command(args)
    if args.rockspec and args.rockspec:match("rockspec$") then
-      return test.run_test_suite(args.rockspec, args.test_type, args.args)
+      return test.run_test_suite(args.rockspec, args.test_type, args.args, args.prepare)
    end
 
    table.insert(args.args, 1, args.rockspec)
@@ -40,8 +41,8 @@ function cmd_test.command(args)
    if not rockspec then
       return nil, err
    end
-
-   return test.run_test_suite(rockspec, args.test_type, args.args)
+   
+   return test.run_test_suite(rockspec, args.test_type, args.args, args.prepare)
 end
 
 return cmd_test

--- a/src/luarocks/core/cfg.lua
+++ b/src/luarocks/core/cfg.lua
@@ -50,6 +50,9 @@ local platform_order = {
 }
 
 local function detect_sysconfdir()
+   if not debug then
+      return
+   end
    local src = debug.getinfo(1, "S").source:gsub("\\", "/"):gsub("/+", "/")
    if src:sub(1, 1) == "@" then
       src = src:sub(2)

--- a/src/luarocks/core/util.lua
+++ b/src/luarocks/core/util.lua
@@ -67,7 +67,10 @@ function util.show_table(t, tname, top_indent)
    local function basic_serialize(o)
       local so = tostring(o)
       if type(o) == "function" then
-         local info = debug.getinfo(o, "S")
+         local info = debug and debug.getinfo(o, "S")
+         if not info then
+            return ("%q"):format(so)
+         end
          -- info.name is nil because o is not a calling level
          if info.what == "C" then
             return ("%q"):format(so .. ", C function")

--- a/src/luarocks/loader.lua
+++ b/src/luarocks/loader.lua
@@ -43,8 +43,8 @@ else
    -- a global.
    -- Detect when being called via -lluarocks.loader; this is
    -- most likely a wrapper.
-   local info = debug.getinfo(2, "nS")
-   if info.what == "C" and not info.name then
+   local info = debug and debug.getinfo(2, "nS")
+   if info and info.what == "C" and not info.name then
       luarocks = { loader = loader }
       temporary_global = true
       -- For the other half of this hack,

--- a/src/luarocks/test.lua
+++ b/src/luarocks/test.lua
@@ -33,7 +33,7 @@ local function get_test_type(rockspec)
 end
 
 -- Run test suite as configured in rockspec in the current directory.
-function test.run_test_suite(rockspec_arg, test_type, args)
+function test.run_test_suite(rockspec_arg, test_type, args, prepare)
    local rockspec
    if type(rockspec_arg) == "string" then
       local err, errcode
@@ -68,7 +68,11 @@ function test.run_test_suite(rockspec_arg, test_type, args)
       return nil, "failed loading test execution module " .. mod_name
    end
 
-   return test_mod.run_tests(rockspec.test, args)
+   if prepare then
+      return test_mod.run_tests(rockspec_arg, {"--version"})
+   else
+      return test_mod.run_tests(rockspec.test, args)
+   end
 end
 
 return test

--- a/src/luarocks/util.lua
+++ b/src/luarocks/util.lua
@@ -23,7 +23,6 @@ local unpack = unpack or table.unpack
 local pack = table.pack or function(...) return { n = select("#", ...), ... } end
 
 local scheduled_functions = {}
-local debug = require("debug")
 
 --- Schedule a function to be executed upon program termination.
 -- This is useful for actions such as deleting temporary directories
@@ -198,7 +197,7 @@ function util.this_program(default)
    local i = 1
    local last, cur = default, default
    while i do
-      local dbg = debug.getinfo(i,"S")
+      local dbg = debug and debug.getinfo(i,"S")
       if not dbg then break end
       last = cur
       cur = dbg.source


### PR DESCRIPTION
This pull request changes the way the `./luarocks` launcher is generated when you run `./configure` and `make`.

This will allow the `./luarocks` command to access dependencies such as `rocks-fs` (which you can install using your system's LuaRocks installation via `sudo luarocks`).

This means that even though the full test suite doesn't run with `./luarocks test` yet, you should be able to run manual tests such as `./luarocks install luafilesystem` and see if there are issues with your changes, such as incorrect references to `fs` functions that were removed, etc.

After merging this PR and `git pull`-ing into your local checkout of the `luarocks-unit` branch, run `make clean`, `./configure` and `make` again to re-generate the wrappers.